### PR TITLE
change: update Docker port mapping to 4000

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Simple repository demonstrating use cases and possible solutions to integrate FG
 ### Run OpenFGA
 
 ```bash
-docker pull openfga/openfga
-docker run -p 8080:8080 -p 8081:8081 -p 3000:3000 openfga/openfga run
+docker pull openfga/openfga:latest
+docker run --rm -e OPENFGA_HTTP_ADDR=0.0.0.0:4000 -p 4000:4000 -p 8081:8081 -p 3000:3000 openfga/openfga run
 ```
 
 See the [OpenFGA docs](https://openfga.dev/docs/getting-started/setup-openfga/docker#step-by-step) for more information.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,7 @@
 openfga:
-  fgaApiUrl: http://localhost:8080
+  fgaApiUrl: http://localhost:4000
   fgaStoreId:
   authorizationModelId:
-
-#TODO run OpenFGA on different port and let spring use default port 8080
-server:
-  port: 4000
 
 logging:
   level:


### PR DESCRIPTION
This PR:

- Updates the `README.md` guidance on `docker run` usage to run the OpenFGA server on port 4000:
  - Added `-e OPENFGA_HTTP_ADDR=0.0.0.0:4000` to configure the OpenFGA server to run on 4000.
  - Added `-rm` to `docker run` to clean up the temporary container after exiting.
  - Updated ~~`-p 8080:8080`~~ to `-p 4000:4000` so port bindings map to the updated value.

- Updates the `src/main/resources/application.yml` configuration to run the app on port 8080:
  - Updated `openfga.fgaApiUrl` from `8080` to `4000` to issue API calls to the updated port.
  - Removed `server.port` so the app now runs on the default 8080 port.

---

### Why use `OPENFGA_HTTP_ADDR` and not just `-p 4000:8080`?

Simply updating the port map to forward host requests from `4000` to the container's `8080` broke a number of things, including the container's built-in playground app.

When the container is running, the playground app is accessible at `http://localhost:3000/playground` on the host. This app proxies its requests using an embedded iframe pointed at `https://play.fga.dev/sandbox/`. The iframe is passed 3 parameters: `fga_api_token`, `fga_api_scheme`, and `fga_api_host`.

`fga_api_host` identifies the local OpenFGA server address in which to issue API calls. It is set to `127.0.0.1:8080` by default, as `8080` is the default configured port for OpenFGA.

The container's applications aren't aware of changes to the host port map configuration, so the `fga_api_host` parameter couldn't reflect the `4000` remapping. Using `OPENFGA_HTTP_ADDR` directly configures the container's OpenFGA server to use the expected port, fixing the issue.